### PR TITLE
Add more user-friendly error handling

### DIFF
--- a/library/bf_assert.py
+++ b/library/bf_assert.py
@@ -155,9 +155,15 @@ def run_module():
 
     try:
         session = create_session(**session_params)
+    except Exception as e:
+        message = 'Failed to establish session with Batfish service: {}'.format(e)
+        module.fail_json(msg=message, **result)
+        return
+
+    try:
         set_snapshot(session=session, network=network, snapshot=snapshot)
     except Exception as e:
-        message = 'Failed to set snapshot for assertions: {}'.format(e)
+        message = 'Failed to set snapshot: {}'.format(e)
         module.fail_json(msg=message, **result)
         return
 

--- a/library/bf_extract_facts.py
+++ b/library/bf_extract_facts.py
@@ -137,7 +137,7 @@ def run_module():
         session = create_session(**session_params)
         set_snapshot(session=session, network=network, snapshot=snapshot)
     except Exception as e:
-        message = 'Failed to select snapshot for extraction: {}'.format(e)
+        message = 'Failed to set snapshot for extraction: {}'.format(e)
         module.fail_json(msg=message, **result)
         return
 

--- a/library/bf_extract_facts.py
+++ b/library/bf_extract_facts.py
@@ -164,7 +164,8 @@ def run_module():
                 module.fail_json(msg='Cannot write facts to file, must be a directory: {}'.format(output_directory))
             write_facts(output_directory, facts)
         except Exception as e:
-            module.fail_json(msg='Failed to write facts: {}'.format(e))
+            message = 'Failed to write facts: {}'.format(e)
+            module.fail_json(msg=message, **result)
         summary += ', wrote facts to directory: {}'.format(output_directory)
 
     # Overall status of command execution

--- a/library/bf_extract_facts.py
+++ b/library/bf_extract_facts.py
@@ -78,7 +78,7 @@ result:
             description: Fact-format version of the returned facts.
             type: str
 '''
-
+import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.bf_util import (create_session, get_facts,
                                           set_snapshot, write_facts)
@@ -133,14 +133,32 @@ def run_module():
     network = module.params.get('network')
     snapshot = module.params.get('snapshot')
 
-    session = create_session(**session_params)
-    set_snapshot(session=session, network=network, snapshot=snapshot)
+    try:
+        session = create_session(**session_params)
+        set_snapshot(session=session, network=network, snapshot=snapshot)
+    except Exception as e:
+        message = 'Failed to select snapshot for extraction: {}'.format(e)
+        module.fail_json(msg=message, **result)
+        return
 
-    facts = get_facts(session=session, nodes_specifier=nodes)
+    try:
+        facts = get_facts(session=session, nodes_specifier=nodes)
+    except Exception as e:
+        message = 'Failed to get facts: {}'.format(e)
+        module.fail_json(msg=message, **result)
+        return
+
     summary = "Got facts for nodes: '{}'".format(nodes)
 
     if output_directory:
-        write_facts(output_directory, facts)
+        try:
+            if not os.path.exists(output_directory):
+                os.makedirs(output_directory)
+            if os.path.isfile(output_directory):
+                module.fail_json(msg='Cannot write facts to file, must be a directory: {}'.format(output_directory))
+            write_facts(output_directory, facts)
+        except Exception as e:
+            module.fail_json(msg='Failed to write facts: {}'.format(e))
         summary += ', wrote facts to directory: {}'.format(output_directory)
 
     # Overall status of command execution

--- a/library/bf_extract_facts.py
+++ b/library/bf_extract_facts.py
@@ -135,9 +135,15 @@ def run_module():
 
     try:
         session = create_session(**session_params)
+    except Exception as e:
+        message = 'Failed to establish session with Batfish service: {}'.format(e)
+        module.fail_json(msg=message, **result)
+        return
+
+    try:
         set_snapshot(session=session, network=network, snapshot=snapshot)
     except Exception as e:
-        message = 'Failed to set snapshot for extraction: {}'.format(e)
+        message = 'Failed to set snapshot: {}'.format(e)
         module.fail_json(msg=message, **result)
         return
 

--- a/library/bf_init_snapshot.py
+++ b/library/bf_init_snapshot.py
@@ -138,10 +138,18 @@ def run_module():
     overwrite = module.params['overwrite']
     session_params = module.params.get('session', {})
 
-    session = create_session(**session_params)
+    try:
+        session = create_session(**session_params)
+    except Exception as e:
+        module.fail_json(msg='Failed to establish session with Batfish service: {}'.format(e))
+        return
 
     session.set_network(network)
-    session.init_snapshot(snapshot_data, snapshot, overwrite=overwrite)
+
+    try:
+        session.init_snapshot(snapshot_data, snapshot, overwrite=overwrite)
+    except Exception as e:
+        module.fail_json(msg='Failed to initialize snapshot: {}'.format(e))
 
     # Overall status of command execution
     result['summary'] = "Snapshot '{}' created in network '{}'".format(snapshot, network)

--- a/library/bf_init_snapshot.py
+++ b/library/bf_init_snapshot.py
@@ -141,7 +141,8 @@ def run_module():
     try:
         session = create_session(**session_params)
     except Exception as e:
-        module.fail_json(msg='Failed to establish session with Batfish service: {}'.format(e))
+        message = 'Failed to establish session with Batfish service: {}'.format(e)
+        module.fail_json(msg=message, **result)
         return
 
     session.set_network(network)
@@ -149,7 +150,8 @@ def run_module():
     try:
         session.init_snapshot(snapshot_data, snapshot, overwrite=overwrite)
     except Exception as e:
-        module.fail_json(msg='Failed to initialize snapshot: {}'.format(e))
+        message = 'Failed to initialize snapshot: {}'.format(e)
+        module.fail_json(msg=message, **result)
 
     # Overall status of command execution
     result['summary'] = "Snapshot '{}' created in network '{}'".format(snapshot, network)

--- a/library/bf_session.py
+++ b/library/bf_session.py
@@ -122,7 +122,10 @@ def run_module():
     parameters['host'] = host
 
     # Not strictly necessary, but useful to confirm the session can be established
-    create_session(**parameters)
+    try:
+        create_session(**parameters)
+    except Exception as e:
+        module.fail_json(msg='Failed to establish session with Batfish service: {}'.format(e))
 
     # Overall status of command execution
     result['summary'] = "Session established to '{}' ({})".format(host, name)

--- a/library/bf_session.py
+++ b/library/bf_session.py
@@ -125,7 +125,8 @@ def run_module():
     try:
         create_session(**parameters)
     except Exception as e:
-        module.fail_json(msg='Failed to establish session with Batfish service: {}'.format(e))
+        message = 'Failed to establish session with Batfish service: {}'.format(e)
+        module.fail_json(msg=message, **result)
 
     # Overall status of command execution
     result['summary'] = "Session established to '{}' ({})".format(host, name)

--- a/library/bf_validate_facts.py
+++ b/library/bf_validate_facts.py
@@ -133,7 +133,7 @@ def run_module():
         session = create_session(**session_params)
         set_snapshot(session=session, network=network, snapshot=snapshot)
     except Exception as e:
-        message = 'Failed to select snapshot for validation: {}'.format(e)
+        message = 'Failed to set snapshot for validation: {}'.format(e)
         module.fail_json(msg=message, **result)
         return
 

--- a/library/bf_validate_facts.py
+++ b/library/bf_validate_facts.py
@@ -131,9 +131,15 @@ def run_module():
 
     try:
         session = create_session(**session_params)
+    except Exception as e:
+        message = 'Failed to establish session with Batfish service: {}'.format(e)
+        module.fail_json(msg=message, **result)
+        return
+
+    try:
         set_snapshot(session=session, network=network, snapshot=snapshot)
     except Exception as e:
-        message = 'Failed to set snapshot for validation: {}'.format(e)
+        message = 'Failed to set snapshot: {}'.format(e)
         module.fail_json(msg=message, **result)
         return
 


### PR DESCRIPTION
Add more user-friendly error handling:
* Do some more input validation (for directories, specifically)
* Wrap most error-prone operations in `try` blocks

Now, instead of getting a long, poorly formatted stack trace in Ansible when an exception occurs (like no running service), a user gets a shorter, more digestible message:
```
TASK [Setup session] *****************************************************************************
fatal: [localhost]: FAILED! => {
  "changed": false,
  "msg": "Failed to establish session with Batfish service: HTTPConnectionPool(host='localhost', port=9997): Max retries exceeded with url: /batfishworkmgr/getquestiontemplates (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x11a32fe80>: Failed to establish a new connection: [Errno 61] Connection refused'))"
}
```