### PR TITLE
Add warnings for snapshot init warnings/failures

### DIFF
--- a/library/bf_init_snapshot.py
+++ b/library/bf_init_snapshot.py
@@ -85,7 +85,9 @@ result:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.bf_util import create_session
+from ansible.module_utils.bf_util import (
+    create_session, get_snapshot_init_warning
+)
 
 try:
     from pybatfish.client.session import Session
@@ -152,6 +154,13 @@ def run_module():
     except Exception as e:
         message = 'Failed to initialize snapshot: {}'.format(e)
         module.fail_json(msg=message, **result)
+
+    try:
+        warn = get_snapshot_init_warning(session)
+        if warn:
+            result['warnings'] = [warn]
+    except Exception as e:
+        result['warnings'] = 'Failed to check snapshot init status: {}'.format(e)
 
     # Overall status of command execution
     result['summary'] = "Snapshot '{}' created in network '{}'".format(snapshot, network)

--- a/module_utils/bf_util.py
+++ b/module_utils/bf_util.py
@@ -17,6 +17,9 @@ import yaml
 from collections import Mapping
 from copy import deepcopy
 from pybatfish.client.session import Session
+from pybatfish.client._diagnostics import (
+    check_if_all_passed, check_if_any_failed, get_snapshot_parse_status
+)
 from pybatfish.datamodel.primitives import ListWrapper
 
 BATFISH_FACT_VERSION = "batfish_v0"
@@ -52,6 +55,16 @@ def set_snapshot(session, network, snapshot):
     """Set the network and snapshot for the specified session."""
     session.set_network(network)
     session.set_snapshot(snapshot)
+
+
+def get_snapshot_init_warning(session):
+    """Return warning message if the snapshot initialization had issues (parse warnings, errors)."""
+    statuses = get_snapshot_parse_status(session)
+    if check_if_any_failed(statuses):
+        return 'Your snapshot was initialized but Batfish failed to parse one or more input files. You can proceed but some analyses may be incorrect.'
+    if not check_if_all_passed(statuses):
+        return 'Your snapshot was successfully initialized but Batfish failed to fully recognized some lines in one or more input files. Some unrecognized configuration lines are not uncommon for new networks, and it is often fine to proceed with further analysis.'
+    return None
 
 
 def get_facts(session, nodes_specifier):


### PR DESCRIPTION
Add warnings for snapshot init warnings/failures

For example, a user would see the following if their snapshot contains some unrecognized lines:
```
TASK [Initialize snapshot] ***********************************************************
 [WARNING]: Your snapshot was successfully initialized but Batfish failed to fully
recognized some lines in one or more input files. Some unrecognized configuration
lines are not uncommon for new networks, and it is often fine to proceed with further
analysis.
```



