### PR TITLE
Fail module on failed assert/validation

### DIFF
--- a/library/bf_assert.py
+++ b/library/bf_assert.py
@@ -85,10 +85,7 @@ summary:
     description: Summary of action(s) performed.
     type: str
 result:
-    description: List of high-level assertion results (name and status).
-    type: list
-result_verbose:
-    description: List of verbose assertion results, containing more details about why assertions failed.
+    description: List of assertion results.
     type: list
 '''
 
@@ -124,7 +121,6 @@ def run_module():
     result = dict(
         changed=False,
         result='',
-        result_verbose='',
         summary='',
     )
 
@@ -158,7 +154,6 @@ def run_module():
         module.exit_json(**result)
 
     results = []
-    results_verbose = []
     failed = []
     summary = 'Assertion(s) completed successfully'
 
@@ -190,22 +185,19 @@ def run_module():
 
         results.append({
             'name': assertion['name'],
-            'status': status,
-        })
-        results_verbose.append({
-            'name': assertion['name'],
             'type': assertion['type'],
             'status': status,
             'details': assert_result,
         })
     if failed:
         summary = '{} of {} assertions failed'.format(len(failed), len(assertions))
-        # Also add this as a warning that shows up in Ansible
-        result['warnings'] = [summary]
 
     result['summary'] = summary
     result['result'] = results
-    result['result_verbose'] = results_verbose
+    # Indicate failure to Ansible in the case of failed assert(s)
+    if failed:
+        module.fail_json(msg=summary, **result)
+
     module.exit_json(**result)
 
 def main():

--- a/library/bf_validate_facts.py
+++ b/library/bf_validate_facts.py
@@ -166,15 +166,15 @@ def run_module():
 
     summary = 'Actual facts match expected facts'
     if failures:
-        summary = ('Validation failed for the following nodes: {}. See task ' +
-                   'output for more details.').format(list(failures.keys()))
+        summary = 'Validation failed for the following nodes: {}.'.format(
+            list(failures.keys()))
 
     # Overall status of command execution
     result['summary'] = summary
     result['result'] = failures
-    # Add warning that shows up in Ansible in the case of failed assert(s)
+    # Indicate failure to Ansible in the case of failed validation
     if failures:
-        result['warnings'] = [summary]
+        module.fail_json(msg=summary, **result)
 
     module.exit_json(**result)
 


### PR DESCRIPTION
Fail module on failed assert/validation

User can add `ignore_errors: yes` as a task-level specifier to continue running subsequent tasks in the event of failure
