### PR TITLE
Make plugin compatible with older version of Ansible

### DIFF
--- a/action_plugins/bf_assert.py
+++ b/action_plugins/bf_assert.py
@@ -16,12 +16,12 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors import AnsibleActionFail
-from ansible.plugins.action.network import ActionModule as ActionNetworkModule
+from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 
 display = Display()
 
-class ActionModule(ActionNetworkModule):
+class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         # Need to use local connect, since Batfish modules run on localhost only
         if self._play_context.connection != 'local':

--- a/action_plugins/bf_extract_facts.py
+++ b/action_plugins/bf_extract_facts.py
@@ -16,12 +16,12 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors import AnsibleActionFail
-from ansible.plugins.action.network import ActionModule as ActionNetworkModule
+from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 
 display = Display()
 
-class ActionModule(ActionNetworkModule):
+class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         # Need to use local connect, since Batfish modules run on localhost only
         if self._play_context.connection != 'local':

--- a/action_plugins/bf_init_snapshot.py
+++ b/action_plugins/bf_init_snapshot.py
@@ -16,12 +16,12 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors import AnsibleActionFail
-from ansible.plugins.action.network import ActionModule as ActionNetworkModule
+from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 
 display = Display()
 
-class ActionModule(ActionNetworkModule):
+class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         # Need to use local connect, since Batfish modules run on localhost only
         if self._play_context.connection != 'local':

--- a/action_plugins/bf_validate_facts.py
+++ b/action_plugins/bf_validate_facts.py
@@ -16,12 +16,12 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors import AnsibleActionFail
-from ansible.plugins.action.network import ActionModule as ActionNetworkModule
+from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 
 display = Display()
 
-class ActionModule(ActionNetworkModule):
+class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         # Need to use local connect, since Batfish modules run on localhost only
         if self._play_context.connection != 'local':


### PR DESCRIPTION
Use action base instead of action module for plugins for better compatibility with older Ansible versions.
