### PR TITLE
Add batch_mode option to Pybatfish setup playbook

### DIFF
--- a/tutorials/playbooks/batfish_pybatfish_setup.yml
+++ b/tutorials/playbooks/batfish_pybatfish_setup.yml
@@ -20,8 +20,9 @@
            prompt: "Do you want to continue? (y/n)"
            echo: yes
          register: venv_prompt
+         when: batch_mode is not defined
 
-      when: python_venv.stdout[0] == "0" 
+      when: python_venv.stdout[0] == "0"
 
 
     - debug:
@@ -29,7 +30,7 @@
 
     - set_fact:
         venv_prompt: "y"
-      when: python_venv.stdout[0] == "1" or venv_prompt.user_input == "Y" or venv_prompt.user_input == "y"
+      when: batch_mode is defined or python_venv.stdout[0] == "1" or venv_prompt.user_input == "Y" or venv_prompt.user_input == "y"
 
 
     - name: Proceeding with pybatfish installation based on user input
@@ -55,4 +56,3 @@
         when: pybatfish_install.changed|bool == true
 
       when: venv_prompt == "Y" or venv_prompt == "y"
-


### PR DESCRIPTION
Add `batch_mode` option to Pybatfish setup playbook.  Skip prompting user when batch_mode fact is set (e.g. running playbook with `--extra-vars "batch_mode=True"`).
