### PR TITLE
Add support for Python 2.7

### DIFF
--- a/module_utils/bf_assertion_util.py
+++ b/module_utils/bf_assertion_util.py
@@ -15,8 +15,8 @@
 
 from collections import Mapping
 from copy import deepcopy
+from sys import version_info
 
-import six
 from pybatfish.client.asserts import (
     assert_filter_has_no_unreachable_lines, assert_filter_denies,
     assert_filter_permits, assert_flows_fail, assert_flows_succeed,
@@ -25,12 +25,12 @@ from pybatfish.client.asserts import (
 )
 from pybatfish.exception import BatfishAssertException
 
-if six.PY3:
+if version_info.major >= 3 and version_info.minor >= 3:
     from inspect import signature
-    from inspect import _empty as inspect_empty
+    from inspect import Parameter
 else:
     from funcsigs import signature
-    from funcsigs import _empty as inspect_empty
+    from funcsigs import Parameter
 
 ASSERTIONS = '''
 assert_all_flows_fail:
@@ -205,7 +205,7 @@ def _get_parameter_issues(assert_type, assert_func, params):
             valid_params)
 
     mandatory_params = {param for param in valid_params if (
-        assert_func_sig.parameters[param].default == inspect_empty)}
+        assert_func_sig.parameters[param].default == Parameter.empty)}
 
     missing_params = mandatory_params - params_key_set
     if len(missing_params) > 0:

--- a/module_utils/bf_assertion_util.py
+++ b/module_utils/bf_assertion_util.py
@@ -25,7 +25,7 @@ from pybatfish.client.asserts import (
 )
 from pybatfish.exception import BatfishAssertException
 
-if version_info.major >= 3 and version_info.minor >= 3:
+if version_info.major > 3 or version_info.major == 3 and version_info.minor >= 3:
     from inspect import signature
     from inspect import Parameter
 else:

--- a/module_utils/bf_assertion_util.py
+++ b/module_utils/bf_assertion_util.py
@@ -19,10 +19,8 @@ from copy import deepcopy
 import six
 from pybatfish.client.asserts import (
     assert_filter_has_no_unreachable_lines, assert_filter_denies,
-    assert_filter_permits,
-    assert_flows_fail, assert_flows_succeed,
-    assert_no_incompatible_bgp_sessions,
-    assert_no_undefined_references,
+    assert_filter_permits, assert_flows_fail, assert_flows_succeed,
+    assert_no_incompatible_bgp_sessions, assert_no_undefined_references,
     assert_no_unestablished_bgp_sessions
 )
 from pybatfish.exception import BatfishAssertException
@@ -177,8 +175,7 @@ def get_assertion_issues(assertion):
     assert_func = _get_asserts_function_from_type(type_)
     if not assert_func:
         return "Unknown assertion type '{}' for assertion '{}'. Valid assert types are: {}".format(
-            type_, name,
-            valid_assert_types)
+            type_, name, valid_assert_types)
 
     parameter_issues = _get_parameter_issues(type_, assert_func, params)
     if parameter_issues:

--- a/module_utils/bf_assertion_util.py
+++ b/module_utils/bf_assertion_util.py
@@ -25,7 +25,7 @@ from pybatfish.client.asserts import (
 )
 from pybatfish.exception import BatfishAssertException
 
-if version_info.major > 3 or version_info.major == 3 and version_info.minor >= 3:
+if version_info >= (3, 3):
     from inspect import signature
     from inspect import Parameter
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML<4.3,>=3.10
+funcsigs;python_version<"3.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML<4.3,>=3.10
-funcsigs;python_version<"3.0"
+funcsigs;python_version<"3.3"

--- a/tutorials/playbooks/batfish_docker_start.yml
+++ b/tutorials/playbooks/batfish_docker_start.yml
@@ -31,7 +31,7 @@
     when: docker_start_status.failed|bool == true
 
   - name: Print Docker Container status
-    debug: msg="Image; {{docker_start_status.container.Config.Image}} - Status; {{docker_start_status.container.State}}"
+    debug: msg="Image; {{docker_container.Config.Image}} - Status; {{docker_container.State}}"
     when: docker_start_status.changed|bool == true
 
   when: service != true


### PR DESCRIPTION
Add support for running modules and tutorials in Python 2.7:
* Use `ansible_fact` instead of module result (which is inconsistent when running in Python 2 vs Python 3) to display docker container status
* Use `funcsigs` in Python 2 instead of `inspect`
* Fix list/set subtraction

Fixed #57