### PR TITLE
Allow specifying session type

### DIFF
--- a/module_utils/bf_util.py
+++ b/module_utils/bf_util.py
@@ -50,11 +50,10 @@ NODE_PROPERTIES_REORG = dict([
 NODE_SPECIFIER_INSTRUCTIONS_URL = 'https://github.com/batfish/batfish/blob/master/questions/Parameters.md#node-specifier'
 
 
-def create_session(**params):
+def create_session(session_type='bf', **params):
     """Create session with the supplied params."""
-    # TODO dynamically determine which session we want to use based on
-    # available modules w/Sessions
-    return Session(**params)
+    # Dynamically import Session class from the specified module
+    return Session.get(type_=session_type, **params)
 
 
 def set_snapshot(session, network, snapshot):

--- a/module_utils/bf_util.py
+++ b/module_utils/bf_util.py
@@ -52,7 +52,6 @@ NODE_SPECIFIER_INSTRUCTIONS_URL = 'https://github.com/batfish/batfish/blob/maste
 
 def create_session(session_type='bf', **params):
     """Create session with the supplied params."""
-    # Dynamically import Session class from the specified module
     return Session.get(type_=session_type, **params)
 
 


### PR DESCRIPTION
Add ability for user to specify which session type to connect to Batfish service with.

User can now _optionally_ specify a session type in their playbook via:
```
    - name: Setup session
      bf_session:
        host: localhost
        name: my_session
        parameters:
          session_type: <session_type> # e.g. bf (Pybatfish session type)
```
