### PR TITLE
Populate assert metadata

### DIFF
--- a/action_plugins/bf_action_plugin_common.py
+++ b/action_plugins/bf_action_plugin_common.py
@@ -86,6 +86,7 @@ class ActionModule(ActionBase):
             if 'bf_policy_name' not in os.environ:
                 os.environ['bf_policy_name'] = self._templar.template(
                     '{{ansible_play_name}}')
+            # Differentiate between different runs of the same policy/play
             if 'bf_policy_id' not in os.environ:
                 os.environ['bf_policy_id'] = self._play_context._uuid
             if 'bf_test_name' not in os.environ:

--- a/module_utils/bf_assertion_util.py
+++ b/module_utils/bf_assertion_util.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import os
 from collections import Mapping
 from copy import deepcopy
 from sys import version_info
@@ -222,6 +223,7 @@ def run_assertion(session, assertion):
     params = deepcopy(assertion.get('parameters', {}))
     params['df_format'] = "records"
 
+    os.environ['bf_assert_name'] = assertion['name']
     assert_ = _get_asserts_function_from_type(type_)
 
     try:


### PR DESCRIPTION
Populate assert metadata in task-specific `env` vars when assertions are run.
