### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The example playbook below outlines how to use the `batfish.base` role to extrac
     when: bf_facts.failed|bool == false
 ```
 
-Note: to connect to a Batfish Enterprise service, just add `parameters: session_type: bfe` to the setup task, e.g.:
+Note: to connect to a Batfish Enterprise service, just add `session_type: bfe` under `parameters:` in the setup task, e.g.:
 ```yaml
   - name: Setup connection to Batfish Enterprise service
     bf_session:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible roles for Batfish
 
-Intentionet has created this Ansible role to allow users to embed [Batfish](https://www.github.com/batfish/batfish) pre-deployment validation into any Ansible playbook. This role is hosted on Ansible Galaxy as `batfish.base`. The role includes a set of Ansible modules that analyze configuration files for an entire (or subset of a) network, allowing users to extract configuration data and perform network-wide validation tests in a completely vendor agnostic manner.
+Intentionet has created this Ansible role to allow users to embed [Batfish](https://www.github.com/batfish/batfish) or [Batfish Enterprise](https://www.intentionet.com/product/batfish-enterprise/) pre-deployment validation into any Ansible playbook. This role is hosted on Ansible Galaxy as `batfish.base`. The role includes a set of Ansible modules that analyze configuration files for an entire (or subset of a) network, allowing users to extract configuration data and perform network-wide validation tests in a completely vendor agnostic manner.
 
 ## Overview of Modules
 
@@ -57,6 +57,16 @@ The example playbook below outlines how to use the `batfish.base` role to extrac
     when: bf_facts.failed|bool == false
 ```
 
+Note: to connect to a Batfish Enterprise service, just add `parameters: session_type: bfe` to the setup task, e.g.:
+```yaml
+  - name: Setup connection to Batfish Enterprise service
+    bf_session:
+      host: localhost
+      name: local_batfish
+      parameters:
+        session_type: bfe
+```
+
 Check out the [tutorials](tutorials) for additional examples.
 
 ## Dependencies
@@ -72,14 +82,15 @@ This module requires the following packages to be installed on the Ansible contr
        python -m pip install -r https://raw.githubusercontent.com/batfish/ansible/master/requirements.txt
        ```
 
-- Running Batfish service and Pybatfish
-
-   - To install Batfish and Pybatfish, you may use the [batfish setup playbook](tutorials/playbooks/batfish_setup.yml) or run the following commands:
+- Batfish service and client
+   - For open-source users: to install Batfish and Pybatfish, you may use the [batfish setup playbook](tutorials/playbooks/batfish_setup.yml) or run the following commands:
       ```
       docker pull batfish/allinone
       docker run -v batfish-data:/data -p 8888:8888 -p 9997:9997 -p 9996:9996 batfish/allinone
       python -m pip install --upgrade git+https://github.com/batfish/pybatfish.git
       ```
+
+   - For enterprise users: follow the instructions delivered with Batfish Enterprise
 
 ## Installation  
 

--- a/library/bf_session.py
+++ b/library/bf_session.py
@@ -22,10 +22,10 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: bf_session
-short_description: Builds a Batfish session for use with other Batfish Ansible modules
+short_description: Builds a session for use with other Batfish Ansible modules
 version_added: "2.7"
 description:
-    - "Builds a Batfish session for use with other Batfish Ansible modules and populates C(bf_session) fact."
+    - "Builds a session for use with other Batfish Ansible modules and populates C(bf_session) fact."
 options:
     host:
         description:
@@ -61,6 +61,13 @@ EXAMPLES = '''
     name: my_session
     parameters:
       ssl: true
+# Establish SSL session with Batfish Enterprise service running at 10.10.10.10
+- bf_session:
+    host: 10.10.10.10
+    name: enterprise_session
+    parameters:
+      ssl: true
+      session_type: bfe
 '''
 
 RETURN = '''
@@ -83,8 +90,9 @@ session:
     returned: always
 '''
 
-from datetime import datetime
 import time
+from datetime import datetime
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.bf_util import create_session
 
@@ -98,6 +106,7 @@ else:
 # Constants for session creation retry
 _MAX_RETRY_TIME = 10
 _RETRY_DELAY = 3
+
 
 def run_module():
     # define the available arguments/parameters that a user can pass to
@@ -153,11 +162,13 @@ def run_module():
         except Exception as session_e:
             if retry_time < _MAX_RETRY_TIME:
                 try_time = (datetime.now() - try_start_time).seconds
-                sleep_time = max(_RETRY_DELAY - try_time, 1)  # sleep at least 1 second
+                sleep_time = max(_RETRY_DELAY - try_time,
+                                 1)  # sleep at least 1 second
                 time.sleep(sleep_time)
                 retry_time += try_time + sleep_time
             else:
-                message = 'Failed to establish session with Batfish service: {}'.format(session_e)
+                message = 'Failed to establish session with Batfish service: {}'.format(
+                    session_e)
                 module.fail_json(msg=message, **result)
 
     # Overall status of command execution
@@ -167,8 +178,10 @@ def run_module():
     result['ansible_facts']['bf_session'] = parameters
     module.exit_json(**result)
 
+
 def main():
     run_module()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
* Add references to `Batfish Enterprise` and add examples using it

FYI: current error message if a user attempts to connect using `bfe` session type without `pybfe` installed:
`Failed to establish session with Batfish service: Invalid session type. Specified type 'bfe' does not match any registered session type: dict_keys(['bf'])`
