### PR TITLE
Install/setup fix

### DIFF
--- a/.buildkite/setup_python.sh
+++ b/.buildkite/setup_python.sh
@@ -14,6 +14,6 @@ export PATH="$HOME/miniconda/bin:$PATH"
 conda create -y -n conda_env python=$1
 source activate conda_env
 # Get around having to build regex since there is no linux wheel in PyPI
-conda install --yes -c conda-forge regex=2019.06.08
+conda install --yes -c conda-forge "regex<=2019.06.08"
 # Install role requirements
 pip install -r requirements.txt

--- a/.buildkite/setup_python.sh
+++ b/.buildkite/setup_python.sh
@@ -14,6 +14,6 @@ export PATH="$HOME/miniconda/bin:$PATH"
 conda create -y -n conda_env python=$1
 source activate conda_env
 # Get around having to build regex since there is no linux wheel in PyPI
-conda install --yes -c conda-forge regex
+conda install --yes -c conda-forge regex=2019.06.08
 # Install role requirements
 pip install -r requirements.txt

--- a/tutorials/playbooks/batfish_pybatfish_setup.yml
+++ b/tutorials/playbooks/batfish_pybatfish_setup.yml
@@ -43,16 +43,40 @@
         debug: msg="Python version 2 detected. We recommend that you use Python 3"
         when: python_installed.stdout is search('Python 2')
 
+      - name: Upgrade pip
+        shell: "python -m pip install --upgrade pip"
+        register: pip_upgrade
+
+      - name: Pip upgrade error
+        debug: msg="Something went wrong"
+        when: pip_upgrade.failed|bool == true
+
+      - name: Print information about pip upgrade
+        debug: msg="{{pip_upgrade.stdout}}"
+        when: pip_upgrade.changed|bool == true
+
       - name: Download and install Pybatfish (Python SDK for Batfish)
-        shell: "python -m pip install --upgrade pip; python -m pip install --upgrade git+https://github.com/batfish/pybatfish.git; python -m pip install -r ../requirements.txt" 
+        shell: "python -m pip install --upgrade git+https://github.com/batfish/pybatfish.git"
         register: pybatfish_install
 
       - name: Pybatfish installation error
         debug: msg="Something went wrong"
         when: pybatfish_install.failed|bool == true
 
-      - name: Print information about image download
+      - name: Print information about Pybatfish install
         debug: msg="{{pybatfish_install.stdout}}"
         when: pybatfish_install.changed|bool == true
+
+      - name: Install tutorial requirements
+        shell: "python -m pip install -r ../requirements.txt"
+        register: requirement_install
+
+      - name: Requirement installation error
+        debug: msg="Something went wrong"
+        when: requirement_install.failed|bool == true
+
+      - name: Print information about requirement install
+        debug: msg="{{requirement_install.stdout}}"
+        when: requirement_install.changed|bool == true
 
       when: venv_prompt == "Y" or venv_prompt == "y"


### PR DESCRIPTION
Fix two issues with install:
* install correct version of `regex` during CI python setup (new version was released, which we were installing in setup, but didn't satisfy `Netconan` requirements)
* split Python setup into separate steps for:
  * failure detection (previously, the Ansible task installing Pybatfish would only fail if the last sub-step [requirements installation] failed)
  * better debug / info visibility

See [here](https://buildkite.com/batfish/ansible-pre-commit/builds/202#0127e90d-0710-4d70-980d-d268395f4e44) for an updated, successful CI run.
