### PR TITLE
Add links to snapshot packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Some of the modules included in the role are:
 
 * **[bf_assert](docs/bf_assert.rst)** - Validate network behavior
 
-See [docs](docs) for a complete list of modules and documentation. 
+See [docs](docs) for a complete list of modules and [tutorials](tutorials) for end-to-end examples. 
 
 ## Examples
 The example playbook below outlines how to use the `batfish.base` role to extract the list of interfaces for all devices in the network.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,7 @@
  *  [bf_set_snapshot](bf_set_snapshot.rst)
  *  [bf_upload_diagnostics](bf_upload_diagnostics.rst)
  *  [bf_validate_facts](bf_validate_facts.rst)
+
+# Additional resources
+ * [Tutorials](../tutorials)
+ * [Packaging your network snapshot](https://pybatfish.readthedocs.io/en/latest/notebooks/interacting.html#Packaging-snapshot-data)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -53,5 +53,5 @@ From the `tutorials` directory, run specific tutorials via
 
  - [Documentation for the Ansible modules](../docs/README.md)
 
- - [Documentation for Batfish](https://github.com/batfish/batfish)
+ - [Packaging your own network snapshots](https://pybatfish.readthedocs.io/en/latest/notebooks/interacting.html#Packaging-snapshot-data)
 


### PR DESCRIPTION
Problem being fixed: A user ran through all the tutorials, and then didn't know what to do next or how to analyze their data. They came across RTD documentation but dismissed it as being meant to python users.