### PR TITLE
Pin Ansible version for testing

### DIFF
--- a/.buildkite/setup_ansible.sh
+++ b/.buildkite/setup_ansible.sh
@@ -2,7 +2,7 @@
 # Setup Ansible and our Batfish Ansible role
 set -euo pipefail
 
-pip install ansible
+pip install "ansible==2.9.9"
 
 # Install our Ansible role from the current branch source
 ROLES_DIR=$HOME/.ansible/roles/


### PR DESCRIPTION
With latest version of Ansible `2.9.10`, CI hangs on:
```
The authenticity of host 'localhost (127.0.0.1)' can't be established.
...
Are you sure you want to continue connecting (yes/no)?
```

Pinning to `2.9.9` for now until we get a chance to dig deeper
